### PR TITLE
Use "$keydir" variable during install

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -191,19 +191,19 @@ class gitolite (
   }
 
   $conffile = "${gitolite::userhome}/.gitolite/conf/gitolite.conf"
-  $keydir   = "${gitolite::userhome}/.gitolite/keydir"
+  $keydir   = "${gitolite::userhome}/.gitolite/key_dir"
   $exec_update = Exec['gitolite_compile', 'gitolite_trigger_post_compile']
 
   # manage initial key, if provided
   if $admin_key_source != '' {
-    file { "${::gitolite::userhome}/.gitoline/key_dir/admin@init0.pub":
+    file { "${keydir}/admin@init0.pub":
       source => $admin_key_source,
       notify => $exec_update,
     }
   }
 
   if $admin_key != '' {
-    file { "${::gitolite::userhome}/.gitoline/key_dir/admin@init1.pub":
+    file { "${keydir}/admin@init1.pub":
       content => $admin_key,
       notify  => $exec_update,
     }


### PR DESCRIPTION
SSH keys were created in the wrong directory, we
now use the declared but unused $keydir variable
to avoid typos.