### PR TITLE
Make the module a bit more flexible, to support other Distributions or operating systems.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -150,7 +150,7 @@ class gitolite (
   }
 
   exec { 'gitolite_setup':
-    command     => "gitolite setup -a dummy; mkdir ~/.gitolite/keydir",
+    command     => "gitolite setup -a admin; mkdir ~/.gitolite/keydir",
     user        =>  "${gitolite::user}",
     environment => [ "HOME=${userhome}" ],
     unless      => "test -d ~${user}/.gitolite",

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -146,14 +146,16 @@ class gitolite (
   }
 
   Exec {
-    path    => ['/usr/bin', '/usr/sbin', '/bin'],
+    path    => ['/usr/bin', '/usr/sbin', '/bin', '/usr/local/bin'],
   }
 
   exec { 'gitolite_setup':
-    command => "su ${gitolite::user} -c 'gitolite setup -a dummy; mkdir ~/.gitolite/keydir'",
-    unless  => "test -d ~${user}/.gitolite",
-    creates => "${userhome}/.gitolite",
-    require => Package[$packages],
+    command     => "gitolite setup -a dummy; mkdir ~/.gitolite/keydir",
+    user        =>  "${gitolite::user}",
+    environment => [ "HOME=${userhome}" ],
+    unless      => "test -d ~${user}/.gitolite",
+    creates     => "${userhome}/.gitolite",
+    require     => Package[$packages],
   }
 
   -> exec { 'gitolite_compile':
@@ -224,7 +226,7 @@ class gitolite (
 
   concat { "${userhome}/upgrade-repos.sh":
     owner => 'root',
-    group => 'root',
+    group => '0',
     mode  => '0700',
   }
 


### PR DESCRIPTION
For now, I only use the module minimally, but the changes:
 * Exec many Operating systems install 3rd party binaries to /usr/local/bin therfore add it to the path list
 * gitaly_setup, it just looked nicer to specify the user and environment, than this ugly su - whoop, which might be less compatible than the Puppet way
 * not on every OS the root group is called 'root', but also often 'wheel' what they have in common is the group id of 0, therefore use that to refer to the root group

With that, a basic usage configured in hiera like that:

gitolite::packages:
  - gitolite gitolite::user: 'git'
gitolite::userhome: '/var/gitolite'

properly installs and configures my gitolite on OpenBSD.